### PR TITLE
Add note about FastAPI constructor arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,50 @@ as well as:
 /v1/openapi.json
 /v2/openapi.json
 ```
+
+## Extra FastAPI constructor arguments
+
+It's important to note that only the `title` from the original FastAPI will be
+provided to the VersionedAPI app. If you have any middleware, event handlers
+etc these arguments will also need to be provided to the VersionedAPI function
+call, as in the example below
+
+```python
+from fastapi import FastAPI, Request
+from fastapi_versioning import VersionedFastAPI, version
+from starlette.middleware import Middleware
+from starlette.middleware.sessions import SessionMiddleware
+
+app = FastAPI(
+    title='My App',
+    description='Greet uses with a nice message',
+    middleware=[
+        Middleware(SessionMiddleware, secret_key='mysecretkey')
+    ]
+)
+
+@app.get('/greet')
+@version(1)
+def greet(request: Request):
+    request.session['last_version_used'] = 1
+    return 'Hello'
+
+@app.get('/greet')
+@version(2)
+def greet(request: Request):
+    request.session['last_version_used'] = 2
+    return 'Hi'
+
+@app.get('/version')
+def last_version(request: Request):
+    return f'Your last greeting was sent from version {request.session["last_version_used"]}'
+
+app = VersionedFastAPI(app,
+    version_format='{major}',
+    prefix_format='/v{major}',
+    description='Greet uses with a nice message',
+    middleware=[
+        Middleware(SessionMiddleware, secret_key='mysecretkey')
+    ]
+)
+```


### PR DESCRIPTION
I just got done trying to figure out why none of my FastAPI middleware's were being loaded and noticed that a new FastAPI object is created by VersionedAPI, but only the title is copied over. This PR updates the README to make this clear, along with a small example based on the existing greet example