### PR TITLE
Replaced deprecated openapi_prefix for root_path.

### DIFF
--- a/fastapi_versioning/versioning.py
+++ b/fastapi_versioning/versioning.py
@@ -49,7 +49,7 @@ def VersionedFastAPI(
             title=app.title,
             description=app.description,
             version=semver,
-            openapi_prefix=prefix,
+            root_path=prefix,
         )
         for route in version_route_mapping[version]:
             for method in route.methods:


### PR DESCRIPTION
Fixes the following annoying warning:

```
"openapi_prefix" has been deprecated in favor of "root_path", which follows more closely the ASGI standard, is simpler, and more automatic. Check the docs at https://fastapi.tiangolo.com/advanced/sub-applications/
```

Fixes #13.