### PR TITLE
add pip package name to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # fastapi-versioning
 api versioning for fastapi web applications
 
+# Installation
+
+`pip install fastapi-versioning`
+
 ## Examples
 ```python
 from fastapi import FastAPI


### PR DESCRIPTION
I think this is pretty convenient for people who wanna try the package out right away.
Maybe also add the PyPI webpage to the repo's webpage info?