### PR TITLE
Support dependency overrides on the versioned app

### DIFF
--- a/fastapi_versioning/versioning.py
+++ b/fastapi_versioning/versioning.py
@@ -36,6 +36,7 @@ def VersionedFastAPI(
         title=app.title,
         **kwargs,
     )
+    parent_app.dependency_overrides = app.dependency_overrides
     version_route_mapping: Dict[Tuple[int, int], List[APIRoute]] = defaultdict(
         list
     )

--- a/tests/test_dependency_overrides.py
+++ b/tests/test_dependency_overrides.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, FastAPI
+from fastapi.testclient import TestClient
+from fastapi_versioning import versioned_api_route, VersionedFastAPI
+
+original_app = FastAPI(title="test-app")
+router = APIRouter(route_class=versioned_api_route(1, 0))
+
+def dependency() -> str:
+    return "original"
+
+@router.get("/test")
+def get_test(dep: str = Depends(dependency)) -> str:
+    return dep
+
+original_app.include_router(router)
+app = VersionedFastAPI(original_app)
+
+
+def test_dependency_override_works() -> None:
+    client = TestClient(app)
+    app.dependency_overrides[dependency] = lambda: "patched"
+    assert client.get("/v1_0/test").json() == "patched", "Dependency override doesn't work"


### PR DESCRIPTION
I ran into this issue, https://github.com/DeanWay/fastapi-versioning/issues/19, and made an easy fix so clients can add the dependency overrides directly to the `VersionedFastAPI`. However, it doesn't work if they overwrite the dependency overrides altogether like so:
```python
app = VersionedFastAPI(app)
app.dependency_overrides = {dependency: lambda: "patched"}
```