### PR TITLE
fix 'latest' version 

### DIFF
--- a/example/annotation/item.py
+++ b/example/annotation/item.py
@@ -53,3 +53,9 @@ def get_item_v2(item_id: str) -> ItemV2:
 @version(1, 2)
 def delete_item(item_id: str) -> None:
     return None
+
+
+@router.post("/item", response_model=ItemV2)
+@version(1, 3)
+def create_item(item: ItemV2) -> ItemV2:
+    return item

--- a/fastapi_versioning/versioning.py
+++ b/fastapi_versioning/versioning.py
@@ -74,18 +74,18 @@ def VersionedFastAPI(
         def noop() -> None:
             ...
 
-    # Use latest endpoint to point to the latest API version available
     if enable_latest:
-        latest_version = versions[-1]
-        major, minor = latest_version
-        prefix = prefix_format.format(major=major, minor=minor)
+        prefix = "/latest"
+        major, minor = version
         semver = version_format.format(major=major, minor=minor)
-
-        @parent_app.get(
-            "/latest/{version_path:path}", name=semver, tags=["Redirect"]
+        versioned_app = FastAPI(
+            title=app.title,
+            description=app.description,
+            version=semver,
+            root_path=prefix,
         )
-        def redirect(version_path: str) -> Response:
-            response = RedirectResponse(url=f"{prefix}/{version_path}")
-            return response
+        for route in unique_routes.values():
+            versioned_app.router.routes.append(route)
+        parent_app.mount(prefix, versioned_app)
 
     return parent_app

--- a/fastapi_versioning/versioning.py
+++ b/fastapi_versioning/versioning.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Dict, List, Tuple, TypeVar, cast
 
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
-from starlette.responses import RedirectResponse, Response
 from starlette.routing import BaseRoute
 
 CallableT = TypeVar("CallableT", bound=Callable[..., Any])

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -19,15 +19,38 @@ def test_annotation_app() -> None:
     assert test_client.get("/v1_1/item/1").status_code == 200
     assert test_client.get("/v1_1/item/1").json()["quantity"] == 5
     complex_quantity = [{"store_id": "1", "quantity": 5}]
+
     assert (
         test_client.get("/v1_2/item/1").json()["quantity"] == complex_quantity
     )
     assert (
         test_client.get("/v1_3/item/1").json()["quantity"] == complex_quantity
     )
+
     assert (
         test_client.get("/latest/item/1").json()["quantity"]
         == complex_quantity
+    )
+
+    item = {
+        "id": "1",
+        "name": "apple",
+        "price": 1.0,
+        "quantity": complex_quantity,
+    }
+    assert (
+        test_client.post(
+            "/v1_3/item",
+            json=item,
+        ).json()
+        == item
+    )
+    assert (
+        test_client.post(
+            "/latest/item",
+            json=item,
+        ).json()
+        == item
     )
 
     assert test_client.delete("/v1_1/item/1").status_code == 405


### PR DESCRIPTION
fixes #47 by mounting a copy of the last version as another child application. This feels a little more stable than using redirects for every interaction when supporting `/latest`