### PR TITLE
Fix in proper root_path propagation

### DIFF
--- a/fastapi_versioning/versioning.py
+++ b/fastapi_versioning/versioning.py
@@ -57,7 +57,7 @@ def VersionedFastAPI(
             title=app.title,
             description=app.description,
             version=semver,
-            root_path=prefix,
+            root_path=parent_app.root_path.rstrip("/") + prefix,
         )
         for route in version_route_mapping[version]:
             for method in route.methods:


### PR DESCRIPTION
Fix for issue #50 allowing openapi docs to be aware of `root_path`, which results in properly generated `openapi.json` url