### PR TITLE
fix: mix up of routes with different major versions

### DIFF
--- a/example/major_version_only/app.py
+++ b/example/major_version_only/app.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+
+from fastapi_versioning import VersionedFastAPI, version
+
+app = FastAPI(title="My Online Store")
+
+
+@app.get("/item")
+@version(1, 0)
+def home_v1() -> str:
+    return "Hello item version 1.0!"
+
+
+@app.get("/other")
+@version(1, 1)
+def home_v1() -> str:
+    return "Hello other version 1.1!"
+
+
+@app.get("/another")
+@version(2, 0)
+def home_v2() -> str:
+    return "Hello another version 2.0!"
+
+
+app = VersionedFastAPI(app)

--- a/fastapi_versioning/versioning.py
+++ b/fastapi_versioning/versioning.py
@@ -45,6 +45,7 @@ def VersionedFastAPI(
     ]
 
     for version, route in version_routes:
+        route.version = version
         version_route_mapping[version].append(route)
 
     unique_routes = {}
@@ -63,7 +64,8 @@ def VersionedFastAPI(
             for method in route.methods:
                 unique_routes[route.path + "|" + method] = route
         for route in unique_routes.values():
-            versioned_app.router.routes.append(route)
+            if major == route.version[0]:
+                versioned_app.router.routes.append(route)
         parent_app.mount(prefix, versioned_app)
 
         @parent_app.get(

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -3,6 +3,7 @@ from starlette.testclient import TestClient
 from example.annotation.app import app as annotation_app
 from example.custom_default_version.app import app as default_version_app
 from example.router.app import app as router_app
+from example.major_version_only.app import app as major_version_only_app
 
 
 def test_annotation_app() -> None:
@@ -87,3 +88,17 @@ def test_default_version() -> None:
 
     assert test_client.get("/v2_0/").json() == "Hello default version 2.0!"
     assert test_client.get("/v3_0/").json() == "Hello version 3.0!"
+
+
+def test_major_version_has_not_previous_major() -> None:
+    test_client = TestClient(major_version_only_app)
+
+    assert test_client.get("/v1_0/item").json() == "Hello item version 1.0!"
+    assert test_client.get("/v1_1/item").json() == "Hello item version 1.0!"
+    assert test_client.get("/v1_1/other").json() == "Hello other version 1.1!"
+    assert test_client.get("/v2_0/another").json() == "Hello another version 2.0!"
+
+    assert test_client.get("/v1_0/another").status_code == 404
+    assert test_client.get("/v1_1/another").status_code == 404
+    assert test_client.get("/v2_0/item").status_code == 404
+    assert test_client.get("/v2_0/other").status_code == 404


### PR DESCRIPTION
Here is a proposal to better handle major versions as the current working mode is that any more recent version contains all routes / methods from previous versions. 