### PR TITLE
Name the "latest" route if enabled

### DIFF
--- a/fastapi_versioning/versioning.py
+++ b/fastapi_versioning/versioning.py
@@ -83,6 +83,6 @@ def VersionedFastAPI(
         )
         for route in unique_routes.values():
             versioned_app.router.routes.append(route)
-        parent_app.mount(prefix, versioned_app)
+        parent_app.mount(prefix, versioned_app, name="latest")
 
     return parent_app


### PR DESCRIPTION
The route is now accessible via request.url_for("latest") method.